### PR TITLE
Update oauthUtils.js

### DIFF
--- a/src/oauthUtils.js
+++ b/src/oauthUtils.js
@@ -19,10 +19,7 @@ export default function makeApiCall (url, method, apiPayload) {
     .then(
       response => response.json(),
 
-      // Do not use catch, because that will also catch
-      // any errors in the dispatch and resulting render,
-      // causing a loop of 'Unexpected batch number' errors.
-      // https://github.com/facebook/react/issues/6895
+
       error => console.error('ERROR', error)
     );
 };


### PR DESCRIPTION
comment not relevant to this code section, though it might be relevant elsewhere in the project, for example would be a more accurate warning of when `catch` can be problematic

```
    makeApiCall(cmsBaseUrl + getVideosEndpoint, 'GET')
      .then((videos) => {
        // This will schedule an update to the component's state
        // which will cause a re-render
        this.setState({
          videoIds: videos.map(v => v.id)
        });
      },
      // Do not use catch, because that will also catch
      // any errors in the dispatch and resulting render,
      // causing a loop of 'Unexpected batch number' errors.
      // https://github.com/facebook/react/issues/6895
      err => console.log(err)
    );
      
```