### PR TITLE
fix undefined variable in getAnalyticsForVideo

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -591,7 +591,7 @@ class AnalyticsFetcher extends Component {
     }
   }
 
-  getAnalyticsForVideo (video) {
+  getAnalyticsForVideo (videoId) {
     const defaultAccountId = '6027103981001';
 
     // Analytics API


### PR DESCRIPTION
In the intro guide, there was a disagreement in variable names in `getAnalyticsForVideo` resulting in a `"videoId" is not defined` error. This changes the argument name from `video` to `videoId` to fix it.